### PR TITLE
The Port :spawn_executable call to execute the dart command uses an absolute path now.

### DIFF
--- a/lib/sass_ex/processor.ex
+++ b/lib/sass_ex/processor.ex
@@ -58,7 +58,11 @@ defmodule SassEx.Processor do
         {:win32, _} -> @win64_command
       end
 
-    port = Port.open({:spawn_executable, command}, [:binary, :exit_status])
+    port =
+      Port.open(
+        {:spawn_executable, Path.expand(Path.dirname(__ENV__.file) <> "/../." <> command)},
+        [:binary, :exit_status]
+      )
 
     {:ok, %{port: port, buffer: <<>>, requests: %{}, last_request_id: 0}}
   end


### PR DESCRIPTION
Adding :sass_ex was causing an exception on application startup:
<img width="1180" alt="Screen Shot 2021-12-11 at 5 42 48 PM" src="https://user-images.githubusercontent.com/57874/145694105-4cfb2e55-c248-4c2c-bba9-249844d0393c.png">

This was resolved by using an absolute path for the command as mentioned in the docs for Port: https://hexdocs.pm/elixir/Port.html#module-spawn_executable. The relative path works fine in the tests for some reason, not sure why. They pass with an absolute path.